### PR TITLE
Refactor: shorten bolts name

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Tests are written using [pytest](https://docs.pytest.org/en/stable/). Tests in P
 
 Along with these we have tests for losses, callbacks and transforms as well.
 
-Have a look at sample tests [here](https://github.com/PyTorchLightning/pytorch-lightning-bolts/tree/master/tests).
+Have a look at sample tests [here](https://github.com/PyTorchLightning/lightning-bolts/tree/master/tests).
 
 After you have added the respective tests, you can run the tests locally with make script:
 
@@ -118,7 +118,7 @@ In case you adding new dependencies, make sure that they are compatible with the
 
 1. **How can I help/contribute?**
 
-   All help is extremely welcome - reporting bugs, fixing documentation, adding test cases, solving issues and preparing bug fixes. To solve some issues you can start with label [good first issue](https://github.com/PyTorchLightning/pytorch-lightning-bolts/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or chose something close to your domain with label [help wanted](https://github.com/PyTorchLightning/pytorch-lightning-bolts/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). Before you start to implement anything check that the issue description that it is clear and self-assign the task to you (if it is not possible, just comment that you take it and we assign it to you...).
+   All help is extremely welcome - reporting bugs, fixing documentation, adding test cases, solving issues and preparing bug fixes. To solve some issues you can start with label [good first issue](https://github.com/PyTorchLightning/lightning-bolts/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or chose something close to your domain with label [help wanted](https://github.com/PyTorchLightning/lightning-bolts/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). Before you start to implement anything check that the issue description that it is clear and self-assign the task to you (if it is not possible, just comment that you take it and we assign it to you...).
 
 2. **Is there a recommendation for branch names?**
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,12 +10,12 @@ Fixes # (issue)
 
 ## Before submitting
 - [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
-- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
+- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
 - [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
 - [ ] Did you make sure to update the documentation with your changes?
 - [ ] Did you write any new necessary tests? [not needed for typos/docs]
 - [ ] Did you verify new and existing tests pass locally with your changes?
-- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?
+- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?
 
 <!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->
 

--- a/.github/workflows/ci_test-base.yml
+++ b/.github/workflows/ci_test-base.yml
@@ -91,7 +91,7 @@ jobs:
       # see: https://github.com/actions/toolkit/issues/399
       continue-on-error: true
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        # token: ${{ secrets.CODECOV_TOKEN }}
         file: coverage.xml
         flags: cpu,pytest
         name: Base-coverage

--- a/.github/workflows/ci_test-full.yml
+++ b/.github/workflows/ci_test-full.yml
@@ -100,7 +100,7 @@ jobs:
       # see: https://github.com/actions/toolkit/issues/399
       continue-on-error: true
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        # token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         flags: unittests
         env_vars: OS,PYTHON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,14 +95,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Enabled PyTorch Lightning 0.10 compatibility ([#264](https://github.com/PyTorchLightning/lightning-bolts/pull/264))
-- Added dummy datasets ([#266](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/266))
-- Added `KittiDataModule` ([#248](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/248))
-- Added `UNet` ([#247](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/247))
-- Added reinforcement learning models, losses and datamodules ([#257](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/257))
+- Added dummy datasets ([#266](https://github.com/PyTorchLightning/lightning-bolts/pull/266))
+- Added `KittiDataModule` ([#248](https://github.com/PyTorchLightning/lightning-bolts/pull/248))
+- Added `UNet` ([#247](https://github.com/PyTorchLightning/lightning-bolts/pull/247))
+- Added reinforcement learning models, losses and datamodules ([#257](https://github.com/PyTorchLightning/lightning-bolts/pull/257))
 
 ## [0.2.2] - 2020-09-14
 
-- Fixed confused logit ([#222](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/222))
+- Fixed confused logit ([#222](https://github.com/PyTorchLightning/lightning-bolts/pull/222))
 
 ## [0.2.1] - 2020-09-13
 
@@ -116,14 +116,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dropped all dependencies except PyTorch Lightning and PyTorch
-- Decoupled datamodules from GAN ([#206](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/206))
-- Modularize AE & VAE ([#196](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/196))
+- Decoupled datamodules from GAN ([#206](https://github.com/PyTorchLightning/lightning-bolts/pull/206))
+- Modularize AE & VAE ([#196](https://github.com/PyTorchLightning/lightning-bolts/pull/196))
 
 ### Fixed
 
-- Fixed gym ([#221](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/221))
-- Fix L1/L2 regularization ([#216](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/216))
-- Fix max_depth recursion crash in AsynchronousLoader ([#191](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/191))
+- Fixed gym ([#221](https://github.com/PyTorchLightning/lightning-bolts/pull/221))
+- Fix L1/L2 regularization ([#216](https://github.com/PyTorchLightning/lightning-bolts/pull/216))
+- Fix max_depth recursion crash in AsynchronousLoader ([#191](https://github.com/PyTorchLightning/lightning-bolts/pull/191))
 
 ## [0.2.0] - 2020-09-10
 
@@ -133,37 +133,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Moved unnecessary dependencies to `__main__` section in BYOL ([#176](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/176))
+- Moved unnecessary dependencies to `__main__` section in BYOL ([#176](https://github.com/PyTorchLightning/lightning-bolts/pull/176))
 
 ### Fixed
 
-- Fixed CPC STL10 finetune ([#173](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/173))
+- Fixed CPC STL10 finetune ([#173](https://github.com/PyTorchLightning/lightning-bolts/pull/173))
 
 ## [0.1.1] - 2020-08-23
 
 ### Added
 
-- Added Faster RCNN + Pscal VOC DataModule ([#157](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/157))
-- Added a better lars scheduling `LARSWrapper` ([#162](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/162))
-- Added CPC finetuner ([#158](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/158))
-- Added `BinaryMNISTDataModule` ([#153](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/153))
-- Added learning rate scheduler to BYOL ([#148](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/148))
-- Added Cityscapes DataModule ([#136](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/136))
-- Added learning rate scheduler `LinearWarmupCosineAnnealingLR` ([#138](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/138))
-- Added BYOL ([#144](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/144))
-- Added `ConfusedLogitCallback` ([#118](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/118))
-- Added an asynchronous single GPU dataloader. ([#1521](https://github.com/PyTorchLightning/pytorch-lightning/pull/1521))
+- Added Faster RCNN + Pscal VOC DataModule ([#157](https://github.com/PyTorchLightning/lightning-bolts/pull/157))
+- Added a better lars scheduling `LARSWrapper` ([#162](https://github.com/PyTorchLightning/lightning-bolts/pull/162))
+- Added CPC finetuner ([#158](https://github.com/PyTorchLightning/lightning-bolts/pull/158))
+- Added `BinaryMNISTDataModule` ([#153](https://github.com/PyTorchLightning/lightning-bolts/pull/153))
+- Added learning rate scheduler to BYOL ([#148](https://github.com/PyTorchLightning/lightning-bolts/pull/148))
+- Added Cityscapes DataModule ([#136](https://github.com/PyTorchLightning/lightning-bolts/pull/136))
+- Added learning rate scheduler `LinearWarmupCosineAnnealingLR` ([#138](https://github.com/PyTorchLightning/lightning-bolts/pull/138))
+- Added BYOL ([#144](https://github.com/PyTorchLightning/lightning-bolts/pull/144))
+- Added `ConfusedLogitCallback` ([#118](https://github.com/PyTorchLightning/lightning-bolts/pull/118))
+- Added an asynchronous single GPU dataloader. ([#1521](https://github.com/PyTorchLightning/lightning/pull/1521))
 
 ### Fixed
 
-- Fixed simclr finetuner ([#165](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/165))
-- Fixed STL10 finetuner ([#164](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/164))
-- Fixed Image GPT ([#108](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/108))
-- Fixed unused MNIST transforms in tran/val/test ([#109](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/109))
+- Fixed simclr finetuner ([#165](https://github.com/PyTorchLightning/lightning-bolts/pull/165))
+- Fixed STL10 finetuner ([#164](https://github.com/PyTorchLightning/lightning-bolts/pull/164))
+- Fixed Image GPT ([#108](https://github.com/PyTorchLightning/lightning-bolts/pull/108))
+- Fixed unused MNIST transforms in tran/val/test ([#109](https://github.com/PyTorchLightning/lightning-bolts/pull/109))
 
 ### Changed
 
-- Enhanced train batch function ([#107](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/107))
+- Enhanced train batch function ([#107](https://github.com/PyTorchLightning/lightning-bolts/pull/107))
 
 ## [0.1.0] - 2020-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,79 +8,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added Pix2Pix model ([#533](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/533))
+- Added Pix2Pix model ([#533](https://github.com/PyTorchLightning/lightning-bolts/pull/533))
 
 ### Changed
 
-- Moved vision models (`GPT2`, `ImageGPT`, `SemSegment`, `UNet`) to `pl_bolts.models.vision` ([#561](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/561))
+- Moved vision models (`GPT2`, `ImageGPT`, `SemSegment`, `UNet`) to `pl_bolts.models.vision` ([#561](https://github.com/PyTorchLightning/lightning-bolts/pull/561))
 
 ### Fixed
 
-- Fixed BYOL moving average update ([#574](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/574))
-- Fixed custom gamma in rl ([#550](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/550))
-- Fixed PyTorch 1.8 compatibility issue ([#580](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/580),
-    [#579](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/579))
-- Fixed handling batchnorms in `BatchGradientVerification` ([#569](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/569))
-- Corrected `num_rows` calculation in `LatentDimInterpolator` callback ([#573](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/573))
+- Fixed BYOL moving average update ([#574](https://github.com/PyTorchLightning/lightning-bolts/pull/574))
+- Fixed custom gamma in rl ([#550](https://github.com/PyTorchLightning/lightning-bolts/pull/550))
+- Fixed PyTorch 1.8 compatibility issue ([#580](https://github.com/PyTorchLightning/lightning-bolts/pull/580),
+    [#579](https://github.com/PyTorchLightning/lightning-bolts/pull/579))
+- Fixed handling batchnorms in `BatchGradientVerification` ([#569](https://github.com/PyTorchLightning/lightning-bolts/pull/569))
+- Corrected `num_rows` calculation in `LatentDimInterpolator` callback ([#573](https://github.com/PyTorchLightning/lightning-bolts/pull/573))
 
 
 ## [0.3.0] - 2021-01-20
 
 ### Added
 
-- Added `input_channels` argument to UNet ([#297](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/297))
-- Added SwAV ([#239](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/239),
-    [#348](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/348),
-    [#323](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/323))
-- Added data monitor callbacks `ModuleDataMonitor` and `TrainingDataMonitor` ([#285](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/285))
-- Added DCGAN module ([#403](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/403)) 
+- Added `input_channels` argument to UNet ([#297](https://github.com/PyTorchLightning/lightning-bolts/pull/297))
+- Added SwAV ([#239](https://github.com/PyTorchLightning/lightning-bolts/pull/239),
+    [#348](https://github.com/PyTorchLightning/lightning-bolts/pull/348),
+    [#323](https://github.com/PyTorchLightning/lightning-bolts/pull/323))
+- Added data monitor callbacks `ModuleDataMonitor` and `TrainingDataMonitor` ([#285](https://github.com/PyTorchLightning/lightning-bolts/pull/285))
+- Added DCGAN module ([#403](https://github.com/PyTorchLightning/lightning-bolts/pull/403)) 
 - Added `VisionDataModule` as parent class for `BinaryMNISTDataModule`, `CIFAR10DataModule`, `FashionMNISTDataModule`, 
-  and `MNISTDataModule` ([#400](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/400))
-- Added GIoU loss ([#347](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/347))
-- Added IoU loss ([#469](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/469))
-- Added semantic segmentation model `SemSegment` with `UNet` backend ([#259](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/259))
-- Added pption to normalize latent interpolation images ([#438](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/438))
-- Added flags to datamodules ([#388](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/388))
-- Added metric GIoU ([#347](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/347))
-- Added Intersection over Union Metric/Loss ([#469](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/469))
-- Added SimSiam model ([#407](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/407))
-- Added gradient verification callback ([#465](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/465))
-- Added Backbones to FRCNN ([#475](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/475))
+  and `MNISTDataModule` ([#400](https://github.com/PyTorchLightning/lightning-bolts/pull/400))
+- Added GIoU loss ([#347](https://github.com/PyTorchLightning/lightning-bolts/pull/347))
+- Added IoU loss ([#469](https://github.com/PyTorchLightning/lightning-bolts/pull/469))
+- Added semantic segmentation model `SemSegment` with `UNet` backend ([#259](https://github.com/PyTorchLightning/lightning-bolts/pull/259))
+- Added pption to normalize latent interpolation images ([#438](https://github.com/PyTorchLightning/lightning-bolts/pull/438))
+- Added flags to datamodules ([#388](https://github.com/PyTorchLightning/lightning-bolts/pull/388))
+- Added metric GIoU ([#347](https://github.com/PyTorchLightning/lightning-bolts/pull/347))
+- Added Intersection over Union Metric/Loss ([#469](https://github.com/PyTorchLightning/lightning-bolts/pull/469))
+- Added SimSiam model ([#407](https://github.com/PyTorchLightning/lightning-bolts/pull/407))
+- Added gradient verification callback ([#465](https://github.com/PyTorchLightning/lightning-bolts/pull/465))
+- Added Backbones to FRCNN ([#475](https://github.com/PyTorchLightning/lightning-bolts/pull/475))
 
 ### Changed
 
-- Decoupled datamodules from models ([#332](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/332),
-    [#270](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/270))
-- Set PyTorch Lightning 1.0 as the minimum requirement ([#274](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/274))
-- Moved `pl_bolts.callbacks.self_supervised.BYOLMAWeightUpdate` to  `pl_bolts.callbacks.byol_updates.BYOLMAWeightUpdate` ([#288](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/288))
-- Moved `pl_bolts.callbacks.self_supervised.SSLOnlineEvaluator` to `pl_bolts.callbacks.ssl_online.SSLOnlineEvaluator` ([#288](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/288))
-- Moved `pl_bolts.datamodules.*_dataset` to `pl_bolts.datasets.*_dataset` ([#275](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/275))
-- Ensured sync across val/test step when using DDP ([#371](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/371))
-- Refactored CLI arguments of models ([#394](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/394))
-- Upgraded DQN to use `.log` ([#404](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/404))
-- Decoupled DataModules from models - CPCV2 ([#386](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/386))
-- Refactored datamodules/datasets ([#338](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/338))
-- Refactored Vision DataModules ([#400](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/400))
-- Refactored `pl_bolts.callbacks` ([#477](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/477))
-- Refactored the rest of `pl_bolts.models.self_supervised` ([#481](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/481),
-    [#479](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/479)
-- Update [`torchvision.utils.make_grid`(https://pytorch.org/docs/stable/torchvision/utils.html#torchvision.utils.make_grid)] kwargs to `TensorboardGenerativeModelImageSampler` ([#494](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/494))
+- Decoupled datamodules from models ([#332](https://github.com/PyTorchLightning/lightning-bolts/pull/332),
+    [#270](https://github.com/PyTorchLightning/lightning-bolts/pull/270))
+- Set PyTorch Lightning 1.0 as the minimum requirement ([#274](https://github.com/PyTorchLightning/lightning-bolts/pull/274))
+- Moved `pl_bolts.callbacks.self_supervised.BYOLMAWeightUpdate` to  `pl_bolts.callbacks.byol_updates.BYOLMAWeightUpdate` ([#288](https://github.com/PyTorchLightning/lightning-bolts/pull/288))
+- Moved `pl_bolts.callbacks.self_supervised.SSLOnlineEvaluator` to `pl_bolts.callbacks.ssl_online.SSLOnlineEvaluator` ([#288](https://github.com/PyTorchLightning/lightning-bolts/pull/288))
+- Moved `pl_bolts.datamodules.*_dataset` to `pl_bolts.datasets.*_dataset` ([#275](https://github.com/PyTorchLightning/lightning-bolts/pull/275))
+- Ensured sync across val/test step when using DDP ([#371](https://github.com/PyTorchLightning/lightning-bolts/pull/371))
+- Refactored CLI arguments of models ([#394](https://github.com/PyTorchLightning/lightning-bolts/pull/394))
+- Upgraded DQN to use `.log` ([#404](https://github.com/PyTorchLightning/lightning-bolts/pull/404))
+- Decoupled DataModules from models - CPCV2 ([#386](https://github.com/PyTorchLightning/lightning-bolts/pull/386))
+- Refactored datamodules/datasets ([#338](https://github.com/PyTorchLightning/lightning-bolts/pull/338))
+- Refactored Vision DataModules ([#400](https://github.com/PyTorchLightning/lightning-bolts/pull/400))
+- Refactored `pl_bolts.callbacks` ([#477](https://github.com/PyTorchLightning/lightning-bolts/pull/477))
+- Refactored the rest of `pl_bolts.models.self_supervised` ([#481](https://github.com/PyTorchLightning/lightning-bolts/pull/481),
+    [#479](https://github.com/PyTorchLightning/lightning-bolts/pull/479)
+- Update [`torchvision.utils.make_grid`(https://pytorch.org/docs/stable/torchvision/utils.html#torchvision.utils.make_grid)] kwargs to `TensorboardGenerativeModelImageSampler` ([#494](https://github.com/PyTorchLightning/lightning-bolts/pull/494))
 
 ### Fixed
 
-- Fixed duplicate warnings when optional packages are unavailable ([#341](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/341))
-- Fixed `ModuleNotFoundError` when importing datamoules ([#303](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/303))
-- Fixed cyclic imports in `pl_bolts.utils.self_suprvised` ([#350](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/350))
-- Fixed VAE loss to use KL term of ELBO ([#330](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/330))
-- Fixed dataloders of `MNISTDataModule` to use `self.batch_size` ([#331](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/331))
-- Fixed missing `outputs` in SSL hooks for PyTorch Lightning 1.0 ([#277](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/277))
-- Fixed stl10 datamodule ([#369](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/369))
-- Fixes SimCLR transforms ([#329](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/329))
-- Fixed binary MNIST datamodule ([#377](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/377))
-- Fixed the end of batch size mismatch ([#389](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/389))
-- Fixed `batch_size` parameter for DataModules remaining ([#344](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/344))
-- Fixed CIFAR `num_samples` ([#432](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/432))
-- Fixed DQN `run_n_episodes` using the wrong environment variable ([#525](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/525))
+- Fixed duplicate warnings when optional packages are unavailable ([#341](https://github.com/PyTorchLightning/lightning-bolts/pull/341))
+- Fixed `ModuleNotFoundError` when importing datamoules ([#303](https://github.com/PyTorchLightning/lightning-bolts/pull/303))
+- Fixed cyclic imports in `pl_bolts.utils.self_suprvised` ([#350](https://github.com/PyTorchLightning/lightning-bolts/pull/350))
+- Fixed VAE loss to use KL term of ELBO ([#330](https://github.com/PyTorchLightning/lightning-bolts/pull/330))
+- Fixed dataloders of `MNISTDataModule` to use `self.batch_size` ([#331](https://github.com/PyTorchLightning/lightning-bolts/pull/331))
+- Fixed missing `outputs` in SSL hooks for PyTorch Lightning 1.0 ([#277](https://github.com/PyTorchLightning/lightning-bolts/pull/277))
+- Fixed stl10 datamodule ([#369](https://github.com/PyTorchLightning/lightning-bolts/pull/369))
+- Fixes SimCLR transforms ([#329](https://github.com/PyTorchLightning/lightning-bolts/pull/329))
+- Fixed binary MNIST datamodule ([#377](https://github.com/PyTorchLightning/lightning-bolts/pull/377))
+- Fixed the end of batch size mismatch ([#389](https://github.com/PyTorchLightning/lightning-bolts/pull/389))
+- Fixed `batch_size` parameter for DataModules remaining ([#344](https://github.com/PyTorchLightning/lightning-bolts/pull/344))
+- Fixed CIFAR `num_samples` ([#432](https://github.com/PyTorchLightning/lightning-bolts/pull/432))
+- Fixed DQN `run_n_episodes` using the wrong environment variable ([#525](https://github.com/PyTorchLightning/lightning-bolts/pull/525))
 
 ## [0.2.5] - 2020-10-12
 
@@ -88,13 +88,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.4] - 2020-10-12
 
-- Enabled manual returns ([#267](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/267))
+- Enabled manual returns ([#267](https://github.com/PyTorchLightning/lightning-bolts/pull/267))
 
 ## [0.2.3] - 2020-10-12
 
 ### Added
 
-- Enabled PyTorch Lightning 0.10 compatibility ([#264](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/264))
+- Enabled PyTorch Lightning 0.10 compatibility ([#264](https://github.com/PyTorchLightning/lightning-bolts/pull/264))
 - Added dummy datasets ([#266](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/266))
 - Added `KittiDataModule` ([#248](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/248))
 - Added `UNet` ([#247](https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/247))

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@
   <a href="https://www.pytorchlightning.ai/">Website</a> •
   <a href="#install">Installation</a> •
   <a href="#main-Goals-of-Bolts">Main goals</a> •
-  <a href="https://pytorch-lightning-bolts.readthedocs.io/en/latest/">latest Docs</a> •
-  <a href="https://pytorch-lightning-bolts.readthedocs.io/en/stable/">stable Docs</a> •
+  <a href="https://lightning-bolts.readthedocs.io/en/latest/">latest Docs</a> •
+  <a href="https://lightning-bolts.readthedocs.io/en/stable/">stable Docs</a> •
   <a href="#team">Community</a> •
   <a href="https://www.grid.ai/">Grid AI</a> •
   <a href="#licence">Licence</a>
 </p>
 
-[![PyPI Status](https://badge.fury.io/py/pytorch-lightning-bolts.svg)](https://badge.fury.io/py/pytorch-lightning-bolts)
-[![PyPI Status](https://pepy.tech/badge/pytorch-lightning-bolts)](https://pepy.tech/project/pytorch-lightning-bolts)
-[![codecov](https://codecov.io/gh/PyTorchLightning/pytorch-lightning-bolts/branch/master/graph/badge.svg)](https://codecov.io/gh/PyTorchLightning/pytorch-lightning-bolts)
-[![CodeFactor](https://www.codefactor.io/repository/github/pytorchlightning/pytorch-lightning-bolts/badge)](https://www.codefactor.io/repository/github/pytorchlightning/pytorch-lightning-bolts)
+[![PyPI Status](https://badge.fury.io/py/lightning-bolts.svg)](https://badge.fury.io/py/lightning-bolts)
+[![PyPI Status](https://pepy.tech/badge/lightning-bolts)](https://pepy.tech/project/lightning-bolts)
+[![codecov](https://codecov.io/gh/PyTorchLightning/lightning-bolts/branch/master/graph/badge.svg)](https://codecov.io/gh/PyTorchLightning/lightning-bolts)
+[![CodeFactor](https://www.codefactor.io/repository/github/pytorchlightning/lightning-bolts/badge)](https://www.codefactor.io/repository/github/pytorchlightning/lightning-bolts)
 
-[![Documentation Status](https://readthedocs.org/projects/pytorch-lightning-bolts/badge/?version=latest)](https://pytorch-lightning-bolts.readthedocs.io/en/latest/)
+[![Documentation Status](https://readthedocs.org/projects/lightning-bolts/badge/?version=latest)](https://lightning-bolts.readthedocs.io/en/latest/)
 [![Slack](https://img.shields.io/badge/slack-chat-green.svg?logo=slack)](https://join.slack.com/t/pytorch-lightning/shared_invite/zt-f6bl2l0l-JYMK3tbAgAmGRrlNr00f1A)
 [![Discourse status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fforums.pytorchlightning.ai)](https://forums.pytorchlightning.ai/)
 [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/PytorchLightning/pytorch-lightning/blob/master/LICENSE)
@@ -41,9 +41,9 @@
 
 | System / PyTorch ver. | 1.6 (min. req.) | 1.7 (latest) |
 | :---: | :---: | :---: |
-| Linux py3.{6,8} | ![CI full testing](https://github.com/PyTorchLightning/pytorch-lightning-bolts/workflows/CI%20full%20testing/badge.svg?branch=master&event=push) | ![CI full testing](https://github.com/PyTorchLightning/pytorch-lightning-bolts/workflows/CI%20full%20testing/badge.svg?branch=master&event=push) |
-| OSX py3.{6,8} | ![CI full testing](https://github.com/PyTorchLightning/pytorch-lightning-bolts/workflows/CI%20full%20testing/badge.svg?branch=master&event=push) | ![CI full testing](https://github.com/PyTorchLightning/pytorch-lightning-bolts/workflows/CI%20full%20testing/badge.svg?branch=master&event=push) |
-| Windows py3.7* | ![CI base testing](https://github.com/PyTorchLightning/pytorch-lightning-bolts/workflows/CI%20base%20testing/badge.svg?branch=master&event=push) | ![CI base testing](https://github.com/PyTorchLightning/pytorch-lightning-bolts/workflows/CI%20base%20testing/badge.svg?branch=master&event=push) |
+| Linux py3.{6,8} | ![CI full testing](https://github.com/PyTorchLightning/lightning-bolts/workflows/CI%20full%20testing/badge.svg?branch=master&event=push) | ![CI full testing](https://github.com/PyTorchLightning/lightning-bolts/workflows/CI%20full%20testing/badge.svg?branch=master&event=push) |
+| OSX py3.{6,8} | ![CI full testing](https://github.com/PyTorchLightning/lightning-bolts/workflows/CI%20full%20testing/badge.svg?branch=master&event=push) | ![CI full testing](https://github.com/PyTorchLightning/lightning-bolts/workflows/CI%20full%20testing/badge.svg?branch=master&event=push) |
+| Windows py3.7* | ![CI base testing](https://github.com/PyTorchLightning/lightning-bolts/workflows/CI%20base%20testing/badge.svg?branch=master&event=push) | ![CI base testing](https://github.com/PyTorchLightning/lightning-bolts/workflows/CI%20base%20testing/badge.svg?branch=master&event=push) |
 
 </center>
 
@@ -53,17 +53,17 @@
 
 Simple installation from PyPI
 ```bash
-pip install pytorch-lightning-bolts
+pip install lightning-bolts
 ```
 
 Install bleeding-edge (no guarantees)   
 ```bash
-pip install git+https://github.com/PytorchLightning/pytorch-lightning-bolts.git@master --upgrade
+pip install git+https://github.com/PytorchLightning/lightning-bolts.git@master --upgrade
 ```
 
 In case you want to have full experience you can install all optional packages at once
 ```bash
-pip install pytorch-lightning-bolts["extra"]
+pip install lightning-bolts["extra"]
 ```
 
 ## What is Bolts

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 [![Documentation Status](https://readthedocs.org/projects/lightning-bolts/badge/?version=latest)](https://lightning-bolts.readthedocs.io/en/latest/)
 [![Slack](https://img.shields.io/badge/slack-chat-green.svg?logo=slack)](https://join.slack.com/t/pytorch-lightning/shared_invite/zt-f6bl2l0l-JYMK3tbAgAmGRrlNr00f1A)
 [![Discourse status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fforums.pytorchlightning.ai)](https://forums.pytorchlightning.ai/)
-[![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/PytorchLightning/pytorch-lightning/blob/master/LICENSE)
+[![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/PytorchLightning/lightning-bolts/blob/master/LICENSE)
 
 <!--
 [![Next Release](https://img.shields.io/badge/Next%20Release-Oct%2005-purple.svg)](https://shields.io/)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 <center>
 
-| System / PyTorch ver. | 1.6 (min. req.) | 1.7 (latest) |
+| System / PyTorch ver. | 1.6 (min. req.) | 1.8 (latest) |
 | :---: | :---: | :---: |
 | Linux py3.{6,8} | ![CI full testing](https://github.com/PyTorchLightning/lightning-bolts/workflows/CI%20full%20testing/badge.svg?branch=master&event=push) | ![CI full testing](https://github.com/PyTorchLightning/lightning-bolts/workflows/CI%20full%20testing/badge.svg?branch=master&event=push) |
 | OSX py3.{6,8} | ![CI full testing](https://github.com/PyTorchLightning/lightning-bolts/workflows/CI%20full%20testing/badge.svg?branch=master&event=push) | ![CI full testing](https://github.com/PyTorchLightning/lightning-bolts/workflows/CI%20full%20testing/badge.svg?branch=master&event=push) |

--- a/docs/source/_templates/theme_variables.jinja
+++ b/docs/source/_templates/theme_variables.jinja
@@ -1,9 +1,9 @@
 {%- set external_urls = {
-  'github': 'https://github.com/PytorchLightning/pytorch-lightning-bolts',
-  'github_issues': 'https://github.com/PytorchLightning/pytorch-lightning-bolts/issues',
+  'github': 'https://github.com/PytorchLightning/lightning-bolts',
+  'github_issues': 'https://github.com/PytorchLightning/lightning-bolts/issues',
   'contributing': 'https://github.com/PytorchLightning/pytorch-lightning/blob/master/CONTRIBUTING.md',
   'governance': 'https://github.com/PytorchLightning/pytorch-lightning/blob/master/governance.md',
-  'docs': 'https://pytorch-lightning-bolts.rtfd.io/en/latest',
+  'docs': 'https://lightning-bolts.rtfd.io/en/latest',
   'twitter': 'https://twitter.com/PyTorchLightnin',
   'discuss': 'https://pytorch-lightning.slack.com',
   'tutorials': 'https://pytorch-lightning.readthedocs.io/en/latest/#tutorials',

--- a/docs/source/_templates/theme_variables.jinja
+++ b/docs/source/_templates/theme_variables.jinja
@@ -1,18 +1,18 @@
 {%- set external_urls = {
   'github': 'https://github.com/PytorchLightning/lightning-bolts',
   'github_issues': 'https://github.com/PytorchLightning/lightning-bolts/issues',
-  'contributing': 'https://github.com/PytorchLightning/pytorch-lightning/blob/master/CONTRIBUTING.md',
+  'contributing': 'https://github.com/PytorchLightning/lightning-bolts/blob/master/CONTRIBUTING.md',
   'governance': 'https://github.com/PytorchLightning/pytorch-lightning/blob/master/governance.md',
   'docs': 'https://lightning-bolts.rtfd.io/en/latest',
   'twitter': 'https://twitter.com/PyTorchLightnin',
   'discuss': 'https://pytorch-lightning.slack.com',
   'tutorials': 'https://pytorch-lightning.readthedocs.io/en/latest/#tutorials',
-  'previous_pytorch_versions': 'https://pytorch-lightning.rtfd.io/en/latest/',
-  'home': 'https://pytorch-lightning.rtfd.io/en/latest/',
+  'previous_pytorch_versions': 'https://pytorch.rtfd.io/en/latest/',
+  'home': 'https://lightning-bolts.rtfd.io/en/latest/',
   'get_started': 'https://pytorch-lightning.readthedocs.io/en/latest/introduction_guide.html',
-  'features': 'https://pytorch-lightning.rtfd.io/en/latest/',
+  'features': 'https://lightning-bolts.rtfd.io/en/latest/',
   'blog': 'https://www.pytorchlightning.ai/blog',
   'resources': 'https://pytorch-lightning.readthedocs.io/en/latest/#community-examples',
-  'support': 'https://pytorch-lightning.rtfd.io/en/latest/',
+  'support': 'https://lightning-bolts.rtfd.io/en/latest/',
 }
 -%}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,7 @@ import pl_bolts  # noqa: E402
 # -- Project information -----------------------------------------------------
 
 # this name shall match the project name in Github as it is used for linking to code
-project = 'PyTorch-Lightning-Bolts'
+project = 'Lightning-Bolts'
 copyright = pl_bolts.__copyright__
 author = pl_bolts.__author__
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-PyTorch-Lightning-Bolts documentation
-=====================================
+Lightning-Bolts documentation
+=============================
 .. toctree::
    :maxdepth: 1
    :name: start

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,17 +5,17 @@ You can install using `pip <https://pypi.org/project/pytorch-lightning/>`_
 
 .. code-block:: bash
 
-   pip install pytorch-lightning-bolts
+   pip install lightning-bolts
 
 Install bleeding-edge (no guarantees)
 
 .. code-block:: bash
 
-   pip install git+https://github.com/PytorchLightning/pytorch-lightning-bolts.git@master --upgrade
+   pip install git+https://github.com/PytorchLightning/lightning-bolts.git@master --upgrade
 
 In case you want to have full experience you can install all optional packages at once
 
 .. code-block:: bash
 
-   pip install pytorch-lightning-bolts["extra"]
+   pip install lightning-bolts["extra"]
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-You can install using `pip <https://pypi.org/project/pytorch-lightning/>`_
+You can install using `pip <https://pypi.org/project/lightning-bolts/>`_
 
 .. code-block:: bash
 

--- a/docs/source/introduction_guide.rst
+++ b/docs/source/introduction_guide.rst
@@ -111,10 +111,10 @@ We accept contributions directly to Bolts or via your own repository.
 To contribute:
 
 1. Submit a pull request to Bolts (we will help you finish it!).
-2. We'll help you add `tests <https://github.com/PyTorchLightning/pytorch-lightning-bolts/tree/master/tests>`_.
+2. We'll help you add `tests <https://github.com/PyTorchLightning/lightning-bolts/tree/master/tests>`_.
 3. We'll help you refactor models to work on `(GPU, TPU, CPU). <https://www.youtube.com/watch?v=neuNEcN9FK4>`_.
 4. We'll help you remove bottlenecks in your model.
-5. We'll help you write up `documentation <https://pytorch-lightning-bolts.readthedocs.io/en/latest/convolutional.html#image-gpt>`_.
+5. We'll help you write up `documentation <https://lightning-bolts.readthedocs.io/en/latest/convolutional.html#image-gpt>`_.
 6. We'll help you pretrain expensive models and host weights for you.
 7. We'll create proper attribution for you and link to your repo.
 8. Once all of this is ready, we will merge into bolts.
@@ -129,7 +129,7 @@ Contribution ideas
 ^^^^^^^^^^^^^^^^^^
 Don't have something to contribute? Ping us on
 `Slack <https://join.slack.com/t/pytorch-lightning/shared_invite/zt-f6bl2l0l-JYMK3tbAgAmGRrlNr00f1A>`_
-or look at our `Github issues <https://github.com/PyTorchLightning/pytorch-lightning-bolts/
+or look at our `Github issues <https://github.com/PyTorchLightning/lightning-bolts/
 issues?q=is%3Aissue+is%3Aopen+label%3A%22Model+to+implement%22>`_!
 
 **We'll help and guide you through the implementation / conversion**

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -60,8 +60,8 @@ Tested
 ^^^^^^
 Models are tested on every PR (on CPUs, GPUs and soon TPUs).
 
-- `Live build <https://github.com/PyTorchLightning/pytorch-lightning-bolts/pull/59/checks>`_
-- `Tests <https://github.com/PyTorchLightning/pytorch-lightning-bolts/tree/master/tests>`_
+- `Live build <https://github.com/PyTorchLightning/lightning-bolts/pull/59/checks>`_
+- `Tests <https://github.com/PyTorchLightning/lightning-bolts/tree/master/tests>`_
 
 Modular
 ^^^^^^^

--- a/docs/source/self_supervised_models.rst
+++ b/docs/source/self_supervised_models.rst
@@ -159,7 +159,7 @@ Results in table are reported from the
      - LR
    * - CIFAR-10
      - 84.52
-     - `CPCresnet101 <https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/pl_bolts/models/self_supervised/cpc/networks.py#L103>`_
+     - `CPCresnet101 <https://github.com/PyTorchLightning/lightning-bolts/blob/master/pl_bolts/models/self_supervised/cpc/networks.py#L103>`_
      - Adam
      - 64
      - 1000 (upto 24 hours)
@@ -167,7 +167,7 @@ Results in table are reported from the
      - 4e-5
    * - STL-10
      - 78.36
-     - `CPCresnet101 <https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/pl_bolts/models/self_supervised/cpc/networks.py#L103>`_
+     - `CPCresnet101 <https://github.com/PyTorchLightning/lightning-bolts/blob/master/pl_bolts/models/self_supervised/cpc/networks.py#L103>`_
      - Adam
      - 144
      - 1000 (upto 72 hours)
@@ -175,7 +175,7 @@ Results in table are reported from the
      - 1e-4
    * - ImageNet
      - 54.82
-     - `CPCresnet101 <https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/pl_bolts/models/self_supervised/cpc/networks.py#L103>`_
+     - `CPCresnet101 <https://github.com/PyTorchLightning/lightning-bolts/blob/master/pl_bolts/models/self_supervised/cpc/networks.py#L103>`_
      - Adam
      - 3072
      - 1000 (upto 21 days)
@@ -311,8 +311,8 @@ CIFAR-10 baseline
      - 1.0/1.5
    * - Ours
      - 88.50
-     - `resnet50 <https://github.com/PyTorchLightning/PyTorch-Lightning-Bolts/blob/master/pl_bolts/models/self_supervised/resnets.py#L301-L309>`_
-     - `LARS-SGD <https://pytorch-lightning-bolts.readthedocs.io/en/latest/api/pl_bolts.optimizers.lars_scheduling.html#pl_bolts.optimizers.lars_scheduling.LARSWrapper>`_
+     - `resnet50 <https://github.com/PyTorchLightning/lightning-bolts/blob/master/pl_bolts/models/self_supervised/resnets.py#L301-L309>`_
+     - `LARS-SGD <https://lightning-bolts.readthedocs.io/en/latest/api/pl_bolts.optimizers.lars_scheduling.html#pl_bolts.optimizers.lars_scheduling.LARSWrapper>`_
      - 2048
      - 800 (4 hours)
      - 8 V100 (16GB)
@@ -400,8 +400,8 @@ Imagenet baseline for SimCLR
      - 4.8
    * - Ours
      - 68.4
-     - `resnet50 <https://github.com/PyTorchLightning/PyTorch-Lightning-Bolts/blob/master/pl_bolts/models/self_supervised/resnets.py#L301-L309>`_
-     - `LARS-SGD <https://pytorch-lightning-bolts.readthedocs.io/en/latest/api/pl_bolts.optimizers.lars_scheduling.html#pl_bolts.optimizers.lars_scheduling.LARSWrapper>`_
+     - `resnet50 <https://github.com/PyTorchLightning/lightning-bolts/blob/master/pl_bolts/models/self_supervised/resnets.py#L301-L309>`_
+     - `LARS-SGD <https://lightning-bolts.readthedocs.io/en/latest/api/pl_bolts.optimizers.lars_scheduling.html#pl_bolts.optimizers.lars_scheduling.LARSWrapper>`_
      - 4096
      - 800
      - 64 V100 (16GB)
@@ -533,7 +533,7 @@ The original paper does not provide baselines on STL10.
    * - Ours
      - `86.72 <https://tensorboard.dev/experiment/w2pq3bPPSxC4VIm5udhA2g/>`_
      - SwAV resnet50
-     - `LARS <https://pytorch-lightning-bolts.readthedocs.io/en/latest/api/pl_bolts.optimizers.lars_scheduling.html#pl_bolts.optimizers.lars_scheduling.LARSWrapper>`_
+     - `LARS <https://lightning-bolts.readthedocs.io/en/latest/api/pl_bolts.optimizers.lars_scheduling.html#pl_bolts.optimizers.lars_scheduling.LARSWrapper>`_
      - 128
      - No
      - 100 (~9 hr)
@@ -629,8 +629,8 @@ Imagenet baseline for SwAV
      - 4.8
    * - Ours
      - 74
-     - `resnet50 <https://github.com/PyTorchLightning/PyTorch-Lightning-Bolts/blob/master/pl_bolts/models/self_supervised/resnets.py#L301-L309>`_
-     - `LARS-SGD <https://pytorch-lightning-bolts.readthedocs.io/en/latest/api/pl_bolts.optimizers.lars_scheduling.html#pl_bolts.optimizers.lars_scheduling.LARSWrapper>`_
+     - `resnet50 <https://github.com/PyTorchLightning/lightning-bolts/blob/master/pl_bolts/models/self_supervised/resnets.py#L301-L309>`_
+     - `LARS-SGD <https://lightning-bolts.readthedocs.io/en/latest/api/pl_bolts.optimizers.lars_scheduling.html#pl_bolts.optimizers.lars_scheduling.LARSWrapper>`_
      - 4096
      - 800
      - 64 V100 (16GB)

--- a/pl_bolts/__init__.py
+++ b/pl_bolts/__init__.py
@@ -7,7 +7,7 @@ __author__ = 'PyTorchLightning et al.'
 __author_email__ = 'name@pytorchlightning.ai'
 __license__ = 'Apache-2.0'
 __copyright__ = f'Copyright (c) 2020-2021, {__author__}'
-__homepage__ = 'https://github.com/PyTorchLightning/pytorch-lightning-bolts'
+__homepage__ = 'https://github.com/PyTorchLightning/lightning-bolts'
 __docs__ = "PyTorch Lightning Bolts is a community contribution for ML researchers."
 __long_doc__ = """
 What is it?

--- a/pl_bolts/setup_tools.py
+++ b/pl_bolts/setup_tools.py
@@ -72,7 +72,7 @@ def _load_readme_description(path_dir: str, homepage: str = __homepage__, ver: s
 
     # readthedocs badge
     text = text.replace('badge/?version=stable', f'badge/?version={ver}')
-    text = text.replace('pytorch-lightning.readthedocs.io/en/stable/', f'pytorch-lightning.readthedocs.io/en/{ver}')
+    text = text.replace('lightning-bolts.readthedocs.io/en/stable/', f'lightning-bolts.readthedocs.io/en/{ver}')
     # codecov badge
     text = text.replace('/branch/master/graph/badge.svg', f'/release/{ver}/graph/badge.svg')
     # replace github badges for release ones

--- a/setup.py
+++ b/setup.py
@@ -37,13 +37,13 @@ def _prepare_extras():
 # the goal of the project is simplicity for researchers, don't want to add too much
 # engineer specific practices
 setup(
-    name='pytorch-lightning-bolts',
+    name='lightning-bolts',
     version=pl_bolts.__version__,
     description=pl_bolts.__docs__,
     author=pl_bolts.__author__,
     author_email=pl_bolts.__author_email__,
     url=pl_bolts.__homepage__,
-    download_url='https://github.com/PyTorchLightning/pytorch-lightning-bolts',
+    download_url='https://github.com/PyTorchLightning/lightning-bolts',
     license=pl_bolts.__license__,
     packages=find_packages(exclude=['tests', 'docs']),
     long_description=_load_readme_description(_PATH_ROOT),
@@ -56,9 +56,9 @@ setup(
     install_requires=_load_requirements(_PATH_ROOT),
     extras_require=_prepare_extras(),
     project_urls={
-        "Bug Tracker": "https://github.com/PyTorchLightning/pytorch-lightning-bolts/issues",
-        "Documentation": "https://pytorch-lightning-bolts.rtfd.io/en/latest/",
-        "Source Code": "https://github.com/PyTorchLightning/pytorch-lightning-bolts",
+        "Bug Tracker": "https://github.com/PyTorchLightning/lightning-bolts/issues",
+        "Documentation": "https://lightning-bolts.rtfd.io/en/latest/",
+        "Source Code": "https://github.com/PyTorchLightning/lightning-bolts",
     },
     classifiers=[
         'Environment :: Console',


### PR DESCRIPTION
## What does this PR do?

make the name consistent with all other PL packages
needed after real rename:
- [ ] rename Read-the-Docs - https://github.com/readthedocs/readthedocs.org/pull/5403

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
