### PR TITLE
Changed key loss to train_loss and val_loss in step accordingly

### DIFF
--- a/pl_bolts/models/self_supervised/simsiam/simsiam_module.py
+++ b/pl_bolts/models/self_supervised/simsiam/simsiam_module.py
@@ -181,7 +181,7 @@ class SimSiam(pl.LightningModule):
         loss = self.cosine_similarity(h1, z2) / 2 + self.cosine_similarity(h2, z1) / 2
 
         # log results
-        self.log_dict({"loss": loss})
+        self.log_dict({"train_loss": loss})
 
         return loss
 
@@ -194,7 +194,7 @@ class SimSiam(pl.LightningModule):
         loss = self.cosine_similarity(h1, z2) / 2 + self.cosine_similarity(h2, z1) / 2
 
         # log results
-        self.log_dict({"loss": loss})
+        self.log_dict({"val_loss": loss})
 
         return loss
 


### PR DESCRIPTION
## What does this PR do?

Changes keys of loss in steps to track train and val loss correctly.

Fixes # (issue)

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
