### PR TITLE
Fix broken links and instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -101,7 +101,7 @@ make test
 
 Want to add a new test case and not sure how? [Talk to us!](https://join.slack.com/t/pytorch-lightning/shared_invite/zt-pw5v393p-qRaDgEk24~EjiZNBpSQFgQ)
 
-**Note before submitting the PR, make sure you have run `make format`.**
+**Note before submitting the PR, make sure you have run `pre-commit run`.**
 ---
 
 ## Guidelines

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -106,7 +106,7 @@ Want to add a new test case and not sure how? [Talk to us!](https://join.slack.c
 
 ## Guidelines
 
-For this section, we refer to read the [parent PL guidelines](https://pytorch-lightning.readthedocs.io/en/latest/CONTRIBUTING.html)
+For this section, we refer to read the [parent PL guidelines](https://pytorch-lightning.readthedocs.io/en/latest/generated/CONTRIBUTING.html)
 
 **Reminder**
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -101,7 +101,7 @@ make test
 
 Want to add a new test case and not sure how? [Talk to us!](https://join.slack.com/t/pytorch-lightning/shared_invite/zt-pw5v393p-qRaDgEk24~EjiZNBpSQFgQ)
 
-**Note before submitting the PR, make sure you have run `make isort`.**
+**Note before submitting the PR, make sure you have run `make format`.**
 ---
 
 ## Guidelines

--- a/docs/source/callbacks.rst
+++ b/docs/source/callbacks.rst
@@ -36,5 +36,5 @@ Creating a callback is simple:
         def on_epoch_end(self, trainer, pl_module):
             # do something
 
-Please refer to `Callback docs <https://pytorch-lightning.readthedocs.io/en/stable/callbacks.html#callback-base>`_
+Please refer to `Callback docs <https://pytorch-lightning.readthedocs.io/en/stable/extensions/callbacks.html#built-in-callbacks>`_
 for a full list of the 20+ hooks available.


### PR DESCRIPTION
## What does this PR do?

I came across a broken link on the [callback page](https://lightning-bolts.readthedocs.io/en/latest/callbacks.html) that is meant to link to a parent page. I have located the correct page and updated the link.

Furthermore, while reading the contributing guide I came across 2 more issues, namely the instruction to run the formatting tools in the `Makefile` are outdated and that the link to the parent contributing guide is also broken. I have fixed them in the same PR since they are all trivial changes.

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
