### PR TITLE
Made val & test loss like train loss in LogisticRegression

### DIFF
--- a/pl_bolts/models/regression/logistic_regression.py
+++ b/pl_bolts/models/regression/logistic_regression.py
@@ -77,8 +77,8 @@ class LogisticRegression(pl.LightningModule):
     def validation_step(self, batch, batch_idx):
         x, y = batch
         x = x.view(x.size(0), -1)
-        y_hat = self(x)
-        acc = accuracy(y_hat, y)
+        y_hat = self.linear(x)
+        acc = accuracy(F.softmax(y_hat, -1), y)
         return {'val_loss': F.cross_entropy(y_hat, y), 'acc': acc}
 
     def validation_epoch_end(self, outputs):
@@ -91,8 +91,8 @@ class LogisticRegression(pl.LightningModule):
     def test_step(self, batch, batch_idx):
         x, y = batch
         x = x.view(x.size(0), -1)
-        y_hat = self(x)
-        acc = accuracy(y_hat, y)
+        y_hat = self.linear(x)
+        acc = accuracy(F.softmax(y_hat, -1), y)
         return {'test_loss': F.cross_entropy(y_hat, y), 'acc': acc}
 
     def test_epoch_end(self, outputs):


### PR DESCRIPTION
## What does this PR do?

Fixes dissimilarity between train & val/test losses introduced by #655 

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
