### PR TITLE
Removing regularisation applied to linear model bias

### DIFF
--- a/pl_bolts/models/regression/linear_regression.py
+++ b/pl_bolts/models/regression/linear_regression.py
@@ -58,12 +58,12 @@ class LinearRegression(pl.LightningModule):
 
         # L1 regularizer
         if self.hparams.l1_strength > 0:
-            l1_reg = sum(param.abs().sum() for param in self.parameters())
+            l1_reg = self.linear.weight.abs().sum()
             loss += self.hparams.l1_strength * l1_reg
 
         # L2 regularizer
         if self.hparams.l2_strength > 0:
-            l2_reg = sum(param.pow(2).sum() for param in self.parameters())
+            l2_reg = self.linear.weight.pow(2).sum()
             loss += self.hparams.l2_strength * l2_reg
 
         loss /= x.size(0)

--- a/pl_bolts/models/regression/logistic_regression.py
+++ b/pl_bolts/models/regression/logistic_regression.py
@@ -61,12 +61,12 @@ class LogisticRegression(pl.LightningModule):
 
         # L1 regularizer
         if self.hparams.l1_strength > 0:
-            l1_reg = sum(param.abs().sum() for param in self.parameters())
+            l1_reg = self.linear.weight.abs().sum()
             loss += self.hparams.l1_strength * l1_reg
 
         # L2 regularizer
         if self.hparams.l2_strength > 0:
-            l2_reg = sum(param.pow(2).sum() for param in self.parameters())
+            l2_reg = self.linear.weight.pow(2).sum()
             loss += self.hparams.l2_strength * l2_reg
 
         loss /= x.size(0)


### PR DESCRIPTION
## What does this PR do?
Fixes #668
Removes the bias from the regularisation applied within linear models.
The regularisation should only apply to the model weights and not the bias.
In the class `training_step` method using `self.parameters()` includes the bias, whereas using `self.linear.weight` ignores it.

The included approach matches that from `sklearn`; I did a _semi-related_ write up to check the removal of the bias against `sklearn` here - https://github.com/stanton119/data-analysis/blob/master/PyTorchStuff/elastic_net/elastic_linear.md

It's my first PR here so please let me know if anything is out of sorts!

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
100% 🙃
