### PR TITLE
Explicit prepare_data(), setup() calls in datamodule docs

### DIFF
--- a/docs/source/datamodules.rst
+++ b/docs/source/datamodules.rst
@@ -26,6 +26,9 @@ Or use it manually with plain PyTorch
 Example::
 
     dm = MNISTDataModule('path/to/data')
+    # download data and setup dataloaders
+    dm.prepare_data()
+    dm.setup()
     for batch in dm.train_dataloader():
         ...
     for batch in dm.val_dataloader():


### PR DESCRIPTION
Hi, 
if I don't call `dm.prepare_data()` and `dm.setup()` the datasets are not yet defined and thus I can't call to get the dataloaders (`dm.train_dataloaders()`). 
I get `AttributeError: 'MNISTDataModule' object has no attribute 'dataset_train'`. 
This should make it clearer, for people who want to simply copy&paste. 

In case I missed something never mind (weird thing is I can't quite find the call to setup() in the previous call to `trainer.fit()` either).

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Fixes # (issue)

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
