### PR TITLE
Support deprecated attribute usage

### DIFF
--- a/pl_bolts/models/rl/double_dqn_model.py
+++ b/pl_bolts/models/rl/double_dqn_model.py
@@ -58,7 +58,7 @@ class DoubleDQN(DQN):
         # calculates training loss
         loss = double_dqn_loss(batch, self.net, self.target_net, self.gamma)
 
-        if self.trainer.use_dp or self.trainer.use_ddp2:
+        if self._use_dp_or_ddp2(self.trainer):
             loss = loss.unsqueeze(0)
 
         # Soft update of target network

--- a/pl_bolts/models/rl/dqn_model.py
+++ b/pl_bolts/models/rl/dqn_model.py
@@ -404,7 +404,8 @@ class DQN(LightningModule):
 
         return arg_parser
 
-    def _use_dp_or_ddp2(self, trainer: Trainer) -> bool:
+    @staticmethod
+    def _use_dp_or_ddp2(trainer: Trainer) -> bool:
         # for backwards compatibility
         if _PL_GREATER_EQUAL_1_4:
             return trainer.accelerator_connector.use_dp or trainer.accelerator_connector.use_ddp2

--- a/pl_bolts/models/rl/dqn_model.py
+++ b/pl_bolts/models/rl/dqn_model.py
@@ -20,7 +20,7 @@ from pl_bolts.models.rl.common.agents import ValueAgent
 from pl_bolts.models.rl.common.gym_wrappers import make_environment
 from pl_bolts.models.rl.common.memory import MultiStepBuffer
 from pl_bolts.models.rl.common.networks import CNN
-from pl_bolts.utils import _GYM_AVAILABLE
+from pl_bolts.utils import _GYM_AVAILABLE, _PL_GREATER_EQUAL_1_4
 from pl_bolts.utils.warnings import warn_missing_pkg
 
 if _GYM_AVAILABLE:
@@ -272,7 +272,7 @@ class DQN(LightningModule):
         # calculates training loss
         loss = dqn_loss(batch, self.net, self.target_net, self.gamma)
 
-        if self.trainer.use_dp or self.trainer.use_ddp2:
+        if self._use_dp_or_ddp2(self.trainer):
             loss = loss.unsqueeze(0)
 
         # Soft update of target network
@@ -403,6 +403,12 @@ class DQN(LightningModule):
         )
 
         return arg_parser
+
+    def _use_dp_or_ddp2(self, trainer: Trainer) -> bool:
+        # for backwards compatibility
+        if _PL_GREATER_EQUAL_1_4:
+            return trainer.accelerator_connector.use_dp or trainer.accelerator_connector.use_ddp2
+        return trainer.use_dp or trainer.use_ddp2
 
 
 def cli_main():

--- a/pl_bolts/models/rl/per_dqn_model.py
+++ b/pl_bolts/models/rl/per_dqn_model.py
@@ -14,7 +14,6 @@ from pl_bolts.datamodules import ExperienceSourceDataset
 from pl_bolts.losses.rl import per_dqn_loss
 from pl_bolts.models.rl.common.memory import Experience, PERBuffer
 from pl_bolts.models.rl.dqn_model import DQN
-from pl_bolts.utils import _PL_GREATER_EQUAL_1_4
 
 
 class PERDQN(DQN):

--- a/pl_bolts/models/rl/per_dqn_model.py
+++ b/pl_bolts/models/rl/per_dqn_model.py
@@ -14,6 +14,7 @@ from pl_bolts.datamodules import ExperienceSourceDataset
 from pl_bolts.losses.rl import per_dqn_loss
 from pl_bolts.models.rl.common.memory import Experience, PERBuffer
 from pl_bolts.models.rl.dqn_model import DQN
+from pl_bolts.utils import _PL_GREATER_EQUAL_1_4
 
 
 class PERDQN(DQN):
@@ -116,7 +117,7 @@ class PERDQN(DQN):
         # calculates training loss
         loss, batch_weights = per_dqn_loss(samples, weights, self.net, self.target_net, self.gamma)
 
-        if self.trainer.use_dp or self.trainer.use_ddp2:
+        if self._use_dp_or_ddp2(self.trainer):
             loss = loss.unsqueeze(0)
 
         # update priorities in buffer

--- a/pl_bolts/models/self_supervised/moco/moco2_module.py
+++ b/pl_bolts/models/self_supervised/moco/moco2_module.py
@@ -335,7 +335,8 @@ class Moco_v2(LightningModule):
 
         return parser
 
-    def _use_ddp_or_ddp2(self, trainer: Trainer) -> bool:
+    @staticmethod
+    def _use_ddp_or_ddp2(trainer: Trainer) -> bool:
         # for backwards compatibility
         if _PL_GREATER_EQUAL_1_4:
             return trainer.accelerator_connector.use_ddp or trainer.accelerator_connector.use_ddp2

--- a/pl_bolts/models/self_supervised/moco/moco2_module.py
+++ b/pl_bolts/models/self_supervised/moco/moco2_module.py
@@ -26,7 +26,7 @@ from pl_bolts.models.self_supervised.moco.transforms import (
     Moco2TrainImagenetTransforms,
     Moco2TrainSTL10Transforms,
 )
-from pl_bolts.utils import _TORCHVISION_AVAILABLE, _PL_GREATER_EQUAL_1_4
+from pl_bolts.utils import _PL_GREATER_EQUAL_1_4, _TORCHVISION_AVAILABLE
 from pl_bolts.utils.warnings import warn_missing_pkg
 
 if _TORCHVISION_AVAILABLE:

--- a/pl_bolts/utils/__init__.py
+++ b/pl_bolts/utils/__init__.py
@@ -38,5 +38,6 @@ _OPENCV_AVAILABLE: bool = _module_available("cv2")
 _WANDB_AVAILABLE: bool = _module_available("wandb")
 _MATPLOTLIB_AVAILABLE: bool = _module_available("matplotlib")
 _TORCHVISION_LESS_THAN_0_9_1: bool = _compare_version("torchvision", operator.lt, "0.9.1")
+_PL_GREATER_EQUAL_1_4 = _compare_version("pytorch_lightning", operator.ge, "1.4.0")
 
 __all__ = ["BatchGradientVerification"]


### PR DESCRIPTION
## What does this PR do?

Reported in Slack by Tran N.M. Hoang

> Hi, I have met a bug when using lightning v1.4 and lightning-bolts to train Moco_v2, it seems that since lightning v1.4, self.trainer.use_ddp2 and self.trainer.use_ddp are removed but Moco_v2 implemented by lightning-bolts stills uses this functionality, so I cannot train Moco_v2 anymore. Can you check it?

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [n/a] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)