### PR TITLE
Fix ImageNet val loader to use val transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed ImageNet val loader to use val transform instead of train transform.
+
 - Fixed the MNIST download giving HTTP 404 with torchvision>=0.9.1 ([#674](https://github.com/PyTorchLightning/lightning-bolts/pull/674))
 
 

--- a/pl_bolts/datamodules/imagenet_datamodule.py
+++ b/pl_bolts/datamodules/imagenet_datamodule.py
@@ -171,7 +171,7 @@ class ImagenetDataModule(LightningDataModule):
             batch_size: the batch size
             transforms: the transforms
         """
-        transforms = self.train_transform() if self.val_transforms is None else self.val_transforms
+        transforms = self.val_transform() if self.val_transforms is None else self.val_transforms
 
         dataset = UnlabeledImagenet(
             self.data_dir,


### PR DESCRIPTION
## What does this PR do?

Fix ImageNet val loader to use val transform instead of train transform

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? \[not needed for typos/docs\]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [X] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

## PR review

- [X] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
