### PR TITLE
[doc fix] Fix input_dim (13 ➡ 10) in linear regression demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ import pytorch_lightning as pl
 X, y = load_diabetes(return_X_y=True)
 loaders = SklearnDataModule(X, y)
 
-model = LinearRegression(input_dim=10)
+model = LinearRegression(input_dim=13)
 
 # try with gpus=4!
 # trainer = pl.Trainer(gpus=4)

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ import pytorch_lightning as pl
 X, y = load_diabetes(return_X_y=True)
 loaders = SklearnDataModule(X, y)
 
-model = LinearRegression(input_dim=13)
+model = LinearRegression(input_dim=10)
 
 # try with gpus=4!
 # trainer = pl.Trainer(gpus=4)

--- a/docs/source/deprecated/models/classic_ml.rst
+++ b/docs/source/deprecated/models/classic_ml.rst
@@ -27,7 +27,7 @@ Add either L1 or L2 regularization, or both, by specifying the regularization st
     X, y = load_diabetes(return_X_y=True)
     loaders = SklearnDataModule(X, y)
 
-    model = LinearRegression(input_dim=13)
+    model = LinearRegression(input_dim=10)
     trainer = pl.Trainer()
     trainer.fit(model, train_dataloader=loaders.train_dataloader(), val_dataloaders=loaders.val_dataloader())
     trainer.test(test_dataloaders=loaders.test_dataloader())


### PR DESCRIPTION
## What does this PR do?
This PR is to fix `input_dim` in linear regression demo of `README.md`. 

Although `input_dim` should be `10` based on [this reference](https://github.com/scikit-learn/scikit-learn/blob/47f888239c507358fc7bab7f832101db648b9461/sklearn/datasets/_base.py#L951), `input_dim=13` in the current version of `README.md`.

If `input_dim=13`, the following error message is raised:

```python
RuntimeError: mat1 and mat2 shapes cannot be multiplied (16x10 and 13x1)
```

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->


## Before submitting

- [ ] ~Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)~
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes?
- [ ] ~Did you write any **new necessary tests**? \[not needed for typos/docs\]~
- [x] ~Did you verify new and **existing tests** pass locally with your changes?~
- [ ] ~If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?~

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review

- [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.


## Did you have fun?

Make sure you had fun coding 🙃
