### PR TITLE
fix: CosineAnnealingLR is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix doctest fails with ImportError: cannot import name 'Env' from 'gym' ([#751](https://github.com/PyTorchLightning/lightning-bolts/pull/751))
+- Fixed doctest fails with ImportError: cannot import name 'Env' from 'gym' ([#751](https://github.com/PyTorchLightning/lightning-bolts/pull/751))
+
+- Fixed MoCo v2 missing Cosine Annealing learning scheduler ([#757](https://github.com/PyTorchLightning/lightning-bolts/pull/757))
 
 ## [0.4.0] - 2021-09-09
 

--- a/pl_bolts/models/self_supervised/moco/moco2_module.py
+++ b/pl_bolts/models/self_supervised/moco/moco2_module.py
@@ -308,7 +308,8 @@ class Moco_v2(LightningModule):
             weight_decay=self.hparams.weight_decay,
         )
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
-            optimizer, self.trainer.max_epochs,
+            optimizer,
+            self.trainer.max_epochs,
         )
         return [optimizer], [scheduler]
 

--- a/pl_bolts/models/self_supervised/moco/moco2_module.py
+++ b/pl_bolts/models/self_supervised/moco/moco2_module.py
@@ -307,7 +307,10 @@ class Moco_v2(LightningModule):
             momentum=self.hparams.momentum,
             weight_decay=self.hparams.weight_decay,
         )
-        return optimizer
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer, self.trainer.max_epochs,
+        )
+        return [optimizer], [scheduler]
 
     @staticmethod
     def add_model_specific_args(parent_parser):


### PR DESCRIPTION
According to [Moco_v2 paper](https://arxiv.org/abs/2003.04297), `cosine lr scheduler` is used but the lighting-bolts's implementation has not implemented it yet.

## What does this PR do?

Add `CosineAnnealingLR` as the learning rate scheduler to follow [Moco_v2 paper](https://arxiv.org/abs/2003.04297)

Fixes # (issue)

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? \[not needed for typos/docs\]
- [ ] Did you verify new and **existing tests** pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review

- [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
