### PR TITLE
Replaced KL divergence estimation with deterministic KL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- VAE now uses deterministic KL divergence during training, previously estimated KL divergence by random sampling ([#760](https://github.com/PyTorchLightning/lightning-bolts/pull/760))
 
 ### Deprecated
 

--- a/pl_bolts/models/autoencoders/basic_vae/basic_vae_module.py
+++ b/pl_bolts/models/autoencoders/basic_vae/basic_vae_module.py
@@ -131,10 +131,7 @@ class VAE(LightningModule):
 
         recon_loss = F.mse_loss(x_hat, x, reduction="mean")
 
-        log_qz = q.log_prob(z)
-        log_pz = p.log_prob(z)
-
-        kl = log_qz - log_pz
+        kl = torch.distributions.kl_divergence(q, p)
         kl = kl.mean()
         kl *= self.kl_coeff
 


### PR DESCRIPTION
## What does this PR do?

Changed the VAE to compute the KL divergence directly during training, instead of estimating it by sampling from the posterior and prior distributions.

Fixes #565

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? \[not needed for typos/docs\]
- [ ] Did you verify new and **existing tests** pass locally with your changes? (I struggled to get them to run)
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

## PR review

- [ ] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.


