### PR TITLE
Allowing torch 1.9.X for SparseMLCallbacks

### DIFF
--- a/pl_bolts/callbacks/sparseml.py
+++ b/pl_bolts/callbacks/sparseml.py
@@ -17,7 +17,7 @@ import torch
 from pytorch_lightning import Callback, LightningModule, Trainer
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
-from pl_bolts.utils import _PL_GREATER_EQUAL_1_4_5, _SPARSEML_AVAILABLE, _TORCH_MAX_VERSION_1_9_0
+from pl_bolts.utils import _PL_GREATER_EQUAL_1_4_5, _SPARSEML_AVAILABLE, _TORCH_MAX_VERSION_SPARSEML
 
 if _SPARSEML_AVAILABLE:
     from sparseml.pytorch.optim import ScheduledModifierManager
@@ -36,8 +36,8 @@ class SparseMLCallback(Callback):
         if not _SPARSEML_AVAILABLE:
             if not _PL_GREATER_EQUAL_1_4_5:
                 raise MisconfigurationException("SparseML requires PyTorch Lightning 1.4.5 or greater.")
-            if not _TORCH_MAX_VERSION_1_9_0:
-                raise MisconfigurationException("SparseML 0.7.0 requires PyTorch version 1.9.0 or lower.")
+            if not _TORCH_MAX_VERSION_SPARSEML:
+                raise MisconfigurationException("SparseML requires PyTorch version lower than 1.10.0.")
             raise MisconfigurationException("SparseML has not be installed, install with pip install sparseml")
         self.manager = ScheduledModifierManager.from_yaml(recipe_path)
 

--- a/pl_bolts/callbacks/sparseml.py
+++ b/pl_bolts/callbacks/sparseml.py
@@ -17,7 +17,7 @@ import torch
 from pytorch_lightning import Callback, LightningModule, Trainer
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
-from pl_bolts.utils import _PL_GREATER_EQUAL_1_4_5, _SPARSEML_AVAILABLE, _TORCH_MAX_VERSION_1_8_1
+from pl_bolts.utils import _PL_GREATER_EQUAL_1_4_5, _SPARSEML_AVAILABLE, _TORCH_MAX_VERSION_SPARSEML
 
 if _SPARSEML_AVAILABLE:
     from sparseml.pytorch.optim import ScheduledModifierManager
@@ -36,8 +36,8 @@ class SparseMLCallback(Callback):
         if not _SPARSEML_AVAILABLE:
             if not _PL_GREATER_EQUAL_1_4_5:
                 raise MisconfigurationException("SparseML requires PyTorch Lightning 1.4.5 or greater.")
-            if not _TORCH_MAX_VERSION_1_8_1:
-                raise MisconfigurationException("SparseML requires PyTorch version 1.8.1 or lower.")
+            if not _TORCH_MAX_VERSION_SPARSEML:
+                raise MisconfigurationException("SparseML 0.7.0 requires PyTorch version 1.9.0 or lower.")
             raise MisconfigurationException("SparseML has not be installed, install with pip install sparseml")
         self.manager = ScheduledModifierManager.from_yaml(recipe_path)
 

--- a/pl_bolts/callbacks/sparseml.py
+++ b/pl_bolts/callbacks/sparseml.py
@@ -17,7 +17,7 @@ import torch
 from pytorch_lightning import Callback, LightningModule, Trainer
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
-from pl_bolts.utils import _PL_GREATER_EQUAL_1_4_5, _SPARSEML_AVAILABLE, _TORCH_MAX_VERSION_SPARSEML
+from pl_bolts.utils import _PL_GREATER_EQUAL_1_4_5, _SPARSEML_AVAILABLE, _TORCH_MAX_VERSION_1_9_0
 
 if _SPARSEML_AVAILABLE:
     from sparseml.pytorch.optim import ScheduledModifierManager
@@ -36,7 +36,7 @@ class SparseMLCallback(Callback):
         if not _SPARSEML_AVAILABLE:
             if not _PL_GREATER_EQUAL_1_4_5:
                 raise MisconfigurationException("SparseML requires PyTorch Lightning 1.4.5 or greater.")
-            if not _TORCH_MAX_VERSION_SPARSEML:
+            if not _TORCH_MAX_VERSION_1_9_0:
                 raise MisconfigurationException("SparseML 0.7.0 requires PyTorch version 1.9.0 or lower.")
             raise MisconfigurationException("SparseML has not be installed, install with pip install sparseml")
         self.manager = ScheduledModifierManager.from_yaml(recipe_path)

--- a/pl_bolts/utils/__init__.py
+++ b/pl_bolts/utils/__init__.py
@@ -42,6 +42,9 @@ _PL_GREATER_EQUAL_1_4 = _compare_version("pytorch_lightning", operator.ge, "1.4.
 _PL_GREATER_EQUAL_1_4_5 = _compare_version("pytorch_lightning", operator.ge, "1.4.5")
 _TORCH_ORT_AVAILABLE = _module_available("torch_ort")
 _TORCH_MAX_VERSION_1_8_1 = _compare_version("torch", operator.le, "1.8.1")
-_SPARSEML_AVAILABLE = _module_available("sparseml") and _PL_GREATER_EQUAL_1_4_5 and _TORCH_MAX_VERSION_1_8_1
+_TORCH_MAX_VERSION_1_9_0 = _compare_version("torch", operator.le, "1.9.0")
+_TORCH_MAX_VERSION_SPARSEML = _TORCH_MAX_VERSION_1_9_0 if _compare_version(
+    "sparseml", operator.ge, "0.7.0") else _TORCH_MAX_VERSION_1_8_1
+_SPARSEML_AVAILABLE = _module_available("sparseml") and _PL_GREATER_EQUAL_1_4_5 and _TORCH_MAX_VERSION_SPARSEML
 
 __all__ = ["BatchGradientVerification"]

--- a/pl_bolts/utils/__init__.py
+++ b/pl_bolts/utils/__init__.py
@@ -41,10 +41,7 @@ _TORCHVISION_LESS_THAN_0_9_1: bool = _compare_version("torchvision", operator.lt
 _PL_GREATER_EQUAL_1_4 = _compare_version("pytorch_lightning", operator.ge, "1.4.0")
 _PL_GREATER_EQUAL_1_4_5 = _compare_version("pytorch_lightning", operator.ge, "1.4.5")
 _TORCH_ORT_AVAILABLE = _module_available("torch_ort")
-_TORCH_MAX_VERSION_1_8_1 = _compare_version("torch", operator.le, "1.8.1")
 _TORCH_MAX_VERSION_1_9_0 = _compare_version("torch", operator.le, "1.9.0")
-_TORCH_MAX_VERSION_SPARSEML = _TORCH_MAX_VERSION_1_9_0 if _compare_version(
-    "sparseml", operator.ge, "0.7.0") else _TORCH_MAX_VERSION_1_8_1
-_SPARSEML_AVAILABLE = _module_available("sparseml") and _PL_GREATER_EQUAL_1_4_5 and _TORCH_MAX_VERSION_SPARSEML
+_SPARSEML_AVAILABLE = _module_available("sparseml") and _PL_GREATER_EQUAL_1_4_5 and _TORCH_MAX_VERSION_1_9_0
 
 __all__ = ["BatchGradientVerification"]

--- a/pl_bolts/utils/__init__.py
+++ b/pl_bolts/utils/__init__.py
@@ -41,7 +41,7 @@ _TORCHVISION_LESS_THAN_0_9_1: bool = _compare_version("torchvision", operator.lt
 _PL_GREATER_EQUAL_1_4 = _compare_version("pytorch_lightning", operator.ge, "1.4.0")
 _PL_GREATER_EQUAL_1_4_5 = _compare_version("pytorch_lightning", operator.ge, "1.4.5")
 _TORCH_ORT_AVAILABLE = _module_available("torch_ort")
-_TORCH_MAX_VERSION_1_9_0 = _compare_version("torch", operator.le, "1.9.0")
-_SPARSEML_AVAILABLE = _module_available("sparseml") and _PL_GREATER_EQUAL_1_4_5 and _TORCH_MAX_VERSION_1_9_0
+_TORCH_MAX_VERSION_SPARSEML = _compare_version("torch", operator.lt, "1.10.0")
+_SPARSEML_AVAILABLE = _module_available("sparseml") and _PL_GREATER_EQUAL_1_4_5 and _TORCH_MAX_VERSION_SPARSEML
 
 __all__ = ["BatchGradientVerification"]


### PR DESCRIPTION
## What does this PR do?

From SparseML >= 0.7.0, the library supports torch 1.9.0. Currently, lightning bolts forces torch 1.8.1.
However, minor revisions of torch doesn't involve major API changes related to pruning or quantization, etc. so I think it is interesting to allow minor revisions (e.g. torch 1.9.1), to allow the use of SparseML while benefitting from potential bug fixes. 

Fixes https://github.com/PyTorchLightning/lightning-bolts/issues/759

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes?
- [x] Did you write any **new necessary tests**? \[not needed for typos/docs\]
- [x] Did you verify new and **existing tests** pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review

- [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
