### PR TITLE
Added `export_kwargs` when exporting sparse onnx

### DIFF
--- a/pl_bolts/callbacks/sparseml.py
+++ b/pl_bolts/callbacks/sparseml.py
@@ -78,9 +78,10 @@ class SparseMLCallback(Callback):
         return max_estimated_steps
 
     @staticmethod
-    def export_to_sparse_onnx(
-        model: LightningModule, output_dir: str, sample_batch: Optional[torch.Tensor] = None
-    ) -> None:
+    def export_to_sparse_onnx(model: LightningModule,
+                              output_dir: str,
+                              sample_batch: Optional[torch.Tensor] = None,
+                              **export_kwargs) -> None:
         """Exports the model to ONNX format."""
         with model._prevent_trainer_and_dataloaders_deepcopy():
             exporter = ModuleExporter(model, output_dir=output_dir)
@@ -91,4 +92,4 @@ class SparseMLCallback(Callback):
                     "``SparseMLCallback.export_to_sparse_onnx(model, output_dir, sample_batch=sample_batch)`` "
                     "or an ``example_input_array`` property within the LightningModule"
                 )
-            exporter.export_onnx(sample_batch=sample_batch)
+            exporter.export_onnx(sample_batch=sample_batch, **export_kwargs)

--- a/pl_bolts/callbacks/sparseml.py
+++ b/pl_bolts/callbacks/sparseml.py
@@ -78,10 +78,9 @@ class SparseMLCallback(Callback):
         return max_estimated_steps
 
     @staticmethod
-    def export_to_sparse_onnx(model: LightningModule,
-                              output_dir: str,
-                              sample_batch: Optional[torch.Tensor] = None,
-                              **export_kwargs) -> None:
+    def export_to_sparse_onnx(
+        model: LightningModule, output_dir: str, sample_batch: Optional[torch.Tensor] = None, **export_kwargs
+    ) -> None:
         """Exports the model to ONNX format."""
         with model._prevent_trainer_and_dataloaders_deepcopy():
             exporter = ModuleExporter(model, output_dir=output_dir)


### PR DESCRIPTION
## What does this PR do?

SparseML's `ModuleExporter` allows an `export_kwargs` (https://github.com/neuralmagic/sparseml/blob/8442a6ef8ba11fb02f5e51472dd68b72438539b9/src/sparseml/pytorch/utils/exporter.py#L161) to be passed to torch.onnx.export, notably `dynamix_axes` that are important to ensure the desired behavior of the export onnx model. Unfortunately, we can't access it through current callback.

Fixes https://github.com/PyTorchLightning/lightning-bolts/issues/758

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes?
- [x] Did you write any **new necessary tests**? \[not needed for typos/docs\]
- [x] Did you verify new and **existing tests** pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review

- [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
