### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/ci_test-full.yml
+++ b/.github/workflows/ci_test-full.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # PyTorch 1.5 is failing on Win and bolts requires torchvision>=0.5
         os: [ubuntu-20.04, macOS-10.15]  #, windows-2019
-        python-version: [3.6, 3.8]
+        python-version: [3.7, 3.9]
         requires: ['minimal', 'latest']
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646

--- a/.github/workflows/ci_test-full.yml
+++ b/.github/workflows/ci_test-full.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # PyTorch 1.5 is failing on Win and bolts requires torchvision>=0.5
         os: [ubuntu-20.04, macOS-10.15]  #, windows-2019
-        python-version: [3.7, 3.9]
+        python-version: [3.7, 3.8]
         requires: ['minimal', 'latest']
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed Python 3.6 support ([#785](https://github.com/PyTorchLightning/lightning-bolts/pull/785))
 
 ### Fixed
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch>=1.6
 torchmetrics>=0.4.1
-pytorch-lightning>=1.3.0
+pytorch-lightning>=1.4.8
 dataclasses ; python_version <= "3.6"
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.6
+torch>=1.7.*
 torchmetrics>=0.4.1
 pytorch-lightning>=1.3.0
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 torch>=1.6
 torchmetrics>=0.4.1
 pytorch-lightning>=1.3.0
-dataclasses ; python_version <= "3.6"
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch>=1.6
 torchmetrics>=0.4.1
-pytorch-lightning>=1.4.8
+pytorch-lightning>=1.3.0
 dataclasses ; python_version <= "3.6"
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.7.*
+torch>=1.6
 torchmetrics>=0.4.1
 pytorch-lightning>=1.3.0
 packaging

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     keywords=["deep learning", "pytorch", "AI"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     setup_requires=["wheel"],
     install_requires=setup_tools._load_requirements(_PATH_ROOT),
     extras_require=_prepare_extras(),

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,6 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],


### PR DESCRIPTION
## What does this PR do?
~`1.4.8`~ Dropping Python 3.6 support should fix the failing tests as commented in https://github.com/PyTorchLightning/lightning-bolts/pull/529#issuecomment-997284658.

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes?
- [n/a] Did you write any **new necessary tests**? \[not needed for typos/docs\]
- [n/a] Did you verify new and **existing tests** pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review

- [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
