### PR TITLE
Updated SparseML callback for latest PyTorch Lightning

### DIFF
--- a/pl_bolts/callbacks/sparseml.py
+++ b/pl_bolts/callbacks/sparseml.py
@@ -67,8 +67,10 @@ class SparseMLCallback(Callback):
             dataset_size = len(trainer.datamodule.train_dataloader())
 
         if hasattr(trainer, 'num_devices'):
+            # New behavior in Lightning
             num_devices = max(1, trainer.num_devices)
         else:
+            # Old behavior deprecated in v1.6
             num_devices = max(1, trainer.num_gpus, trainer.num_processes)
             if trainer.tpu_cores:
                 num_devices = max(num_devices, trainer.tpu_cores)

--- a/pl_bolts/callbacks/sparseml.py
+++ b/pl_bolts/callbacks/sparseml.py
@@ -66,14 +66,17 @@ class SparseMLCallback(Callback):
         else:
             dataset_size = len(trainer.datamodule.train_dataloader())
 
-        num_devices = max(1, trainer.num_gpus, trainer.num_processes)
-        if trainer.tpu_cores:
-            num_devices = max(num_devices, trainer.tpu_cores)
+        if hasattr(trainer, 'num_devices'):
+            num_devices = max(1, trainer.num_devices)
+        else:
+            num_devices = max(1, trainer.num_gpus, trainer.num_processes)
+            if trainer.tpu_cores:
+                num_devices = max(num_devices, trainer.tpu_cores)
 
         effective_batch_size = trainer.accumulate_grad_batches * num_devices
         max_estimated_steps = dataset_size // effective_batch_size
 
-        if trainer.max_steps and trainer.max_steps < max_estimated_steps:
+        if trainer.max_steps != -1 and trainer.max_steps < max_estimated_steps:
             return trainer.max_steps
         return max_estimated_steps
 

--- a/pl_bolts/callbacks/sparseml.py
+++ b/pl_bolts/callbacks/sparseml.py
@@ -76,8 +76,10 @@ class SparseMLCallback(Callback):
         effective_batch_size = trainer.accumulate_grad_batches * num_devices
         max_estimated_steps = dataset_size // effective_batch_size
 
-        if trainer.max_steps != -1 and trainer.max_steps < max_estimated_steps:
-            return trainer.max_steps
+        # To avoid breaking changes, max_steps is set to -1 if it is not defined
+        max_steps = -1 if not trainer.max_steps else trainer.max_steps
+        if max_steps != -1 and max_steps < max_estimated_steps:
+            return max_steps
         return max_estimated_steps
 
     @staticmethod


### PR DESCRIPTION
## What does this PR do?

It fixes an issue, where `steps_per_epoch` had to be positive. With recent pl lightning, it is -1 so it raises an error.

* Fix for `max_steps` (now defaults to `-1`), leading the callback to pass `trainer.max_steps` to `steps_per_epoch`, raising an error,
* Fix for deprecation of `num_gpus`, `num_processes` and `tpu_cores`. Those attributes will be deleted, and we should use `num_devices` instead. To avoid breaking changes, the old behavior stays the same if `trainer` has no `num_devices` attribute.

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? \[not needed for typos/docs\]
- [x] Did you verify new and **existing tests** pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review

- [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
